### PR TITLE
BasePhaseLoader: Allow parameters to be specified in 'options' blocks

### DIFF
--- a/src/main/java/edu/cmu/lti/oaqa/ecd/phase/BasePhaseLoader.java
+++ b/src/main/java/edu/cmu/lti/oaqa/ecd/phase/BasePhaseLoader.java
@@ -90,7 +90,7 @@ public final class BasePhaseLoader {
       } else {
         String resource = (String) first.getValue();
         List<AnalysisEngineDescription> options = doLoadOptions(ResourceHandle.newHandle(type,
-                resource));
+                resource), description);
         aes.addAll(options);
       }
     } catch (Exception e) {
@@ -166,8 +166,12 @@ public final class BasePhaseLoader {
   }
 
   private List<AnalysisEngineDescription> doLoadOptions(ResourceHandle handle) throws Exception {
-    List<AnalysisEngineDescription> aes = Lists.newArrayList();
     Map<String, Object> tuples = Maps.newLinkedHashMap();
+    return doLoadOptions(handle, tuples);
+  }
+
+  private List<AnalysisEngineDescription> doLoadOptions(ResourceHandle handle, Map<String, Object> tuples) throws Exception {
+    List<AnalysisEngineDescription> aes = Lists.newArrayList();
     Class<? extends AnalysisComponent> comp = BaseExperimentBuilder.loadFromClassOrInherit(handle,
             AnalysisComponent.class, tuples);
     AnyObject crossParams = (AnyObject) tuples.remove(CROSS_PARAMS_KEY);


### PR DESCRIPTION
This allows ECD blocks like:

'''
- inherit: jdbc.sqlite.cse.phase
  name: information-extractor
  options: |
  - inherit: phases.ie.fixedregex
    regex: "\$[^.]*"
    '''

i.e. specifying parameters inline in the options block rather than only
in the inherited ECDs.
